### PR TITLE
fix utf8 issues in jpostal

### DIFF
--- a/src/jpostal/c/jpostal_AddressExpander.c
+++ b/src/jpostal/c/jpostal_AddressExpander.c
@@ -26,8 +26,17 @@ JNIEXPORT void JNICALL Java_com_mapzen_jpostal_AddressExpander_setupDataDir
 }
 
 JNIEXPORT jobjectArray JNICALL Java_com_mapzen_jpostal_AddressExpander_libpostalExpand
-  (JNIEnv *env, jclass cls, jstring jAddress, jobject jOptions) {
-    const char *address = (*env)->GetStringUTFChars(env, jAddress, 0);
+  (JNIEnv *env, jclass cls, jbyteArray jAddress, jobject jOptions) {
+    jbyte* addressElements = (*env)->GetByteArrayElements(env, jAddress, NULL);
+    jsize size = (*env)->GetArrayLength(env, jAddress);
+    char address[size + 1];
+
+    for (size_t z = 0; z < size; z++) {
+        address[z] = addressElements[z];
+    }
+    (*env) -> ReleaseByteArrayElements(env, jAddress, addressElements, 0);
+
+    address[size] = '\0';
 
     size_t num_expansions = 0;
     libpostal_normalize_options_t options = libpostal_get_default_options();
@@ -210,16 +219,17 @@ JNIEXPORT jobjectArray JNICALL Java_com_mapzen_jpostal_AddressExpander_libpostal
 
     char **expansions = libpostal_expand_address((char *)address, options, &num_expansions);
 
-    (*env)->ReleaseStringUTFChars(env, jAddress, address);
 
     jobjectArray ret = (jobjectArray)(*env)->NewObjectArray(env,
                                                             num_expansions,
-                                                            (*env)->FindClass(env, "java/lang/String"),
+                                                            (*env)->FindClass(env, "[B"),
                                                             (*env)->NewStringUTF(env, ""));
 
     if (num_expansions > 0) {
         for (size_t i = 0; i < num_expansions; i++) {
-            (*env)->SetObjectArrayElement(env, ret, i, (*env)->NewStringUTF(env, expansions[i]));
+            jbyteArray bytes = (*env)->NewByteArray(env,strlen(expansions[i]));
+            (*env)->SetByteArrayRegion(env, bytes, 0, strlen(expansions[i]), (jbyte*) expansions[i]);
+            (*env)->SetObjectArrayElement(env, ret, i, bytes);
         }
 
     }

--- a/src/jpostal/c/jpostal_AddressParser.c
+++ b/src/jpostal/c/jpostal_AddressParser.c
@@ -1,5 +1,6 @@
 #include <jni.h>
 #include <libpostal/libpostal.h>
+#include <string.h>
 
 JNIEXPORT void JNICALL Java_com_mapzen_jpostal_AddressParser_setup
   (JNIEnv *env, jclass cls) {
@@ -24,9 +25,19 @@ JNIEXPORT void JNICALL Java_com_mapzen_jpostal_AddressParser_setupDataDir
 }
 
 JNIEXPORT jobjectArray JNICALL Java_com_mapzen_jpostal_AddressParser_libpostalParse
-  (JNIEnv *env, jobject thisObj, jstring jAddress, jobject jOptions) {
+  (JNIEnv *env, jobject thisObj, jbyteArray jAddress, jobject jOptions) {
+    
+    jbyte* addressElements = (*env)->GetByteArrayElements(env, jAddress, NULL);
+    jsize size = (*env)->GetArrayLength(env, jAddress);
+    char address[size + 1];
 
-    const char *address = (*env)->GetStringUTFChars(env, jAddress, 0);
+    for (int i = 0; i < size; ++i) {
+        address[i] = addressElements[i];
+    }
+    (*env) -> ReleaseByteArrayElements(env, jAddress, addressElements, 0);
+
+    address[size] = '\0';
+
 
     libpostal_address_parser_options_t options = libpostal_get_address_parser_default_options();
 
@@ -58,8 +69,6 @@ JNIEXPORT jobjectArray JNICALL Java_com_mapzen_jpostal_AddressParser_libpostalPa
 
     libpostal_address_parser_response_t *response = libpostal_parse_address((char *)address, options);
 
-    (*env)->ReleaseStringUTFChars(env, jAddress, address);
-
     if (jLanguage != NULL) {
         (*env)->ReleaseStringUTFChars(env, jLanguage, 0);
     }
@@ -71,7 +80,7 @@ JNIEXPORT jobjectArray JNICALL Java_com_mapzen_jpostal_AddressParser_libpostalPa
     jmethodID mid;
 
     jclass parsedComponentClass = (*env)->FindClass(env, "com/mapzen/jpostal/ParsedComponent");
-    mid = (*env)->GetMethodID(env, parsedComponentClass, "<init>", "(Ljava/lang/String;Ljava/lang/String;)V");
+    mid = (*env)->GetMethodID(env, parsedComponentClass, "<init>", "([BLjava/lang/String;)V");
 
     size_t num_components = response != NULL ? response->num_components : 0;
 
@@ -82,12 +91,16 @@ JNIEXPORT jobjectArray JNICALL Java_com_mapzen_jpostal_AddressParser_libpostalPa
 
     if (num_components > 0) {
         for (size_t i = 0; i < num_components; i++) {
-            jstring jComponent = (*env)->NewStringUTF(env, response->components[i]);
             jstring jLabel = (*env)->NewStringUTF(env, response->labels[i]);
-
-            jobject jParsedComponent = (*env)->NewObject(env, parsedComponentClass, mid, jComponent, jLabel);
-
+            jbyteArray bytes = (*env)->NewByteArray(env,strlen(response->components[i]));
+            (*env)->SetByteArrayRegion(env, bytes, 0, strlen(response->components[i]), (jbyte*) response->components[i]);
+            jobject jParsedComponent = (*env)->NewObject(env, parsedComponentClass, mid, bytes, jLabel);
             (*env)->SetObjectArrayElement(env, ret, i, jParsedComponent);
+
+            // // These might be necessary to help ensure we're not leaking memory in the cluster.
+            // (*env)->DeleteLocalRef(env, bytes);
+            // (*env)->DeleteLocalRef(env, jLabel);
+            // (*env)->DeleteLocalRef(env, jParsedComponent);
         }
     }
 
@@ -129,4 +142,3 @@ JNIEXPORT void JNICALL Java_com_mapzen_jpostal_ParserOptions_00024Builder_setDef
     (*env)->SetObjectField(env, builder, fid, NULL);
 
 }
-

--- a/src/main/java/com/mapzen/jpostal/AddressExpander.java
+++ b/src/main/java/com/mapzen/jpostal/AddressExpander.java
@@ -2,6 +2,8 @@ package com.mapzen.jpostal;
 
 import com.mapzen.jpostal.ExpanderOptions;
 
+import java.nio.charset.StandardCharsets;
+
 public class AddressExpander {
     static {
         System.loadLibrary("jpostal"); // Load native library at runtime
@@ -27,7 +29,7 @@ public class AddressExpander {
 
     static native synchronized void setup();
     static native synchronized void setupDataDir(String dataDir);
-    private static native synchronized String[] libpostalExpand(String address, ExpanderOptions options);
+    private static native synchronized byte[][] libpostalExpand(byte[] address, ExpanderOptions options);
     static native synchronized void teardown();
 
     public String[] expandAddress(String address) {
@@ -43,7 +45,12 @@ public class AddressExpander {
         }
 
         synchronized(this) {
-            return libpostalExpand(address, options);
+            byte[][] expansionBytes = libpostalExpand(address.getBytes(), options);
+            String expansions[] = new String[expansionBytes.length];
+            for (int i = 0; i < expansionBytes.length; i++) {
+                expansions[i] = new String(expansionBytes[i], StandardCharsets.UTF_8);
+            }
+            return expansions;
         }
     }
 

--- a/src/main/java/com/mapzen/jpostal/AddressParser.java
+++ b/src/main/java/com/mapzen/jpostal/AddressParser.java
@@ -10,7 +10,7 @@ public class AddressParser {
 
     static native synchronized void setup();
     static native synchronized void setupDataDir(String dataDir);
-    private native synchronized ParsedComponent[] libpostalParse(String address, ParserOptions options);
+    private native synchronized ParsedComponent[] libpostalParse(byte[] address, ParserOptions options);
     static native synchronized void teardown();
 
     private volatile static AddressParser instance = null;
@@ -43,7 +43,7 @@ public class AddressParser {
         }
 
         synchronized(this) {
-            return libpostalParse(address, options);
+            return libpostalParse(address.getBytes(), options);
         }
     } 
 

--- a/src/main/java/com/mapzen/jpostal/ParsedComponent.java
+++ b/src/main/java/com/mapzen/jpostal/ParsedComponent.java
@@ -1,5 +1,7 @@
 package com.mapzen.jpostal;
 
+import java.nio.charset.StandardCharsets;
+
 public class ParsedComponent {
     private String value;
     private String label;
@@ -22,6 +24,11 @@ public class ParsedComponent {
 
     public ParsedComponent(String value, String label) {
         this.value = value;
+        this.label = label;
+    }
+
+    public ParsedComponent(byte[] value, String label) {
+        this.value = new String(value, StandardCharsets.UTF_8);
         this.label = label;
     }
 }

--- a/src/test/java/com/mapzen/jpostal/TestAddressExpander.java
+++ b/src/test/java/com/mapzen/jpostal/TestAddressExpander.java
@@ -60,5 +60,18 @@ public class TestAddressExpander {
         assertTrue(containsExpansionWithOptions("30 West Twenty-sixth St Fl No. 7", "30 west 26th street floor number 7", englishOptions));
     }
 
+    @Test
+    public void testNulTerminatedExpansion() {
+        assertTrue(containsExpansion("123 Main St\u0000", "123 main street"));
+    }
 
+    @Test
+    public void testAltNulTerminatedExpansion() {
+        assertTrue(containsExpansion("123 Main St\0", "123 main street"));
+    }
+
+    @Test
+    public void test4ByteCharacterExpansion() {
+        assertTrue(containsExpansion("123 Main St, 𠜎𠜱𠝹𠱓, 😀🤠", "123 main street 𠜎𠜱𠝹𠱓 😀🤠"));
+    }
 }

--- a/src/test/java/com/mapzen/jpostal/TestAddressParser.java
+++ b/src/test/java/com/mapzen/jpostal/TestAddressParser.java
@@ -56,4 +56,31 @@ public class TestAddressParser {
                   new ParsedComponent("usa", "country")
                  );
     }
+
+    @Test
+    public void testParseNulTerminatedAddress() {
+        testParse("Rue du Médecin-Colonel Calbairac Toulouse France\u0000", 
+                  new ParsedComponent("rue du médecin-colonel calbairac", "road"),
+                  new ParsedComponent("toulouse", "city"),
+                  new ParsedComponent("france", "country")
+                 );
+    }
+
+    @Test
+    public void testParseAltNulTerminatedAddress() {
+        testParse("Rue du Médecin-Colonel Calbairac Toulouse France\0", 
+                  new ParsedComponent("rue du médecin-colonel calbairac", "road"),
+                  new ParsedComponent("toulouse", "city"),
+                  new ParsedComponent("france", "country")
+                 );
+    }
+
+    @Test
+    public void testParse4ByteCharacterAddress() {
+        testParse("𠜎𠜱𠝹𠱓, 😀🤠, London, UK", 
+                  new ParsedComponent("𠜎𠜱𠝹𠱓 😀🤠", "house"),
+                  new ParsedComponent("london", "city"),
+                  new ParsedComponent("uk", "country")
+                 );
+    }
 }


### PR DESCRIPTION
Full context in https://github.com/OvertureMaps/overture-matchers/issues/56.

This is the modified version of jpostal we're currently using in our cluster for places. It is a minimally modified version of an [open PR in the original jpostal repo](https://github.com/openvenues/jpostal/pull/38) addressing the same issue. The main modification is fixing the byte array size to include the null termination character at the end.

The issue originates from the fact that libpostal expects standard UTF-8, but Java uses a modified UTF8 version, so by working with jstrings by default at the JNI layer, you end up passing unexpected/malformed UTF-8 characters to libpostal, which eventually makes the library crash and/or hang depending on the environment it's running in. In the case of Spark clusters, this was hanging nodes indefinitely after an issue in the transliteration module of libpostal.

This issue was particularly reproducible with Meta's feed, given the presence of international places in all sorts of languages and character sets. 

This requires JDK8 to build locally.

> [!IMPORTANT]
> While switching from jstring to jbytes allows us to work around the issue, it introduces additional risk of memory leaks happening. Keep an eye out if you observe any workers dying with OOM or similar errors. I was able to successfully compute addresses for all of Meta's dataset without seeing any issues, but we should make sure that is the case for running the full setup flow in the matcher as well.